### PR TITLE
Oaj cite

### DIFF
--- a/app/controllers/oa_cite_identifiers_controller.rb
+++ b/app/controllers/oa_cite_identifiers_controller.rb
@@ -91,7 +91,8 @@ class OaCiteIdentifiersController < IdentifiersController
     end
     agent_client = AgentHelper::get_client(agent)
     collection = AgentHelper::get_target_collection(agent,:OajCiteIdentifier)
-    uri = Cite::CiteLib::object_uuid_urn(collection)
+    urn = Cite::CiteLib::object_uuid_urn(collection)
+    uri = SITE_CITE_COLLECTION_NAMESPACE + "/" + urn
     creator = url_for(:host => SITE_USER_NAMESPACE, :controller => 'user', :action => 'show', :user_name => @identifier.publication.creator.name, :only_path => false)
     @converted = agent_client.get_content(params[:resource],uri,creator)
     if (@converted[:error]) 
@@ -102,7 +103,7 @@ class OaCiteIdentifiersController < IdentifiersController
       end
     else 
       if params[:create]
-        newobj = OajCiteIdentifier.new_from_supplied(@identifier.publication,uri,JSON.pretty_generate(@converted[:data]))
+        newobj = OajCiteIdentifier.new_from_supplied(@identifier.publication,urn,JSON.pretty_generate(@converted[:data]))
         flash[:notice] = "File created."
         expire_publication_cache
         redirect_to polymorphic_path([@identifier.publication, newobj],

--- a/app/controllers/oaj_cite_identifiers_controller.rb
+++ b/app/controllers/oaj_cite_identifiers_controller.rb
@@ -1,7 +1,7 @@
 class OajCiteIdentifiersController < IdentifiersController
   layout SITE_LAYOUT
   before_filter :authorize
-  before_filter :ownership_guard, :only => [:edit, :update]
+  before_filter :ownership_guard, :only => [:edit, :update, :destroy]
 
 
   def edit

--- a/app/controllers/oaj_cite_identifiers_controller.rb
+++ b/app/controllers/oaj_cite_identifiers_controller.rb
@@ -1,8 +1,42 @@
 class OajCiteIdentifiersController < IdentifiersController
   layout SITE_LAYOUT
   before_filter :authorize
-  before_filter :ownership_guard, :only => [:update]
+  before_filter :ownership_guard, :only => [:edit, :update]
 
+
+  def edit
+    find_identifier
+    @is_editor_view = true
+  end
+
+  def update
+    find_identifier
+    # NB use of xml_content nomenclature is just to allow us to make use of
+    # the validate functionality which runs a preprocess step -- in this
+    # case a JSON parse
+    xml_content = params[@identifier.class.to_s.underscore][:xml_content].gsub(/\r\n?/, "\n")
+    begin
+      commit_sha = @identifier.set_xml_content(xml_content,:comment => params[:comment])
+      if params[:comment] != nil && params[:comment].strip != ""
+        @comment = Comment.new( {:git_hash => commit_sha, :user_id => @current_user.id, :identifier_id => @identifier.origin.id, :publication_id => @identifier.publication.origin.id, :comment => params[:comment].to_s, :reason => "commit" } )
+        @comment.save
+      end
+      
+      flash[:notice] = "File updated."
+      expire_publication_cache
+      if %w{new editing}.include?@identifier.publication.status
+        flash[:notice] += " Go to the <a href='#{url_for(@identifier.publication)}'>publication overview</a> if you would like to submit."
+      end
+    rescue => parse_error
+      Rails.logger.info(parse_error.backtrace)
+      @identifier[:xml_content] = xml_content
+      flash[:error] = parse_error.to_str + ". This file was NOT SAVED."
+      render :template => 'oaj_cite_identifiers/edit'
+      return
+    end
+    redirect_to polymorphic_path([@identifier.publication, @identifier],
+                                 :action => :edit) and return
+  end
 
   def create
     @publication = Publication.find(params[:publication_id].to_s)

--- a/app/controllers/oaj_cite_identifiers_controller.rb
+++ b/app/controllers/oaj_cite_identifiers_controller.rb
@@ -1,0 +1,65 @@
+class OajCiteIdentifiersController < IdentifiersController
+  layout SITE_LAYOUT
+  before_filter :authorize
+  before_filter :ownership_guard, :only => [:update]
+
+
+  def create
+    @publication = Publication.find(params[:publication_id].to_s)
+    
+    # use the default collection if one wasn't specified
+    urn = params[:urn]
+    content = params[:init_value]
+
+    # required params: publication_id, urn, init_value
+    unless (@publication && urn)
+      flash[:error] = "Unable to create item. Missing urn."
+      redirect_to dashboard_url
+      return
+    end
+    
+    # make sure we have a valid collection 
+    if Cite::CiteLib::get_collection(collection_urn).nil?
+      flash[:error] = "Unable to create item. Unknown collection."
+      redirect_to dashboard_url
+      return
+    end
+
+    newobj = OajCiteIdentifier.new_from_supplied(@publication,collection_urn,valid_targets)
+    flash[:notice] = "File created."
+    expire_publication_cache
+    redirect_to polymorphic_path([@identifier.publication, newobj],
+                                 :action => :preview) and return
+  end
+
+  def preview
+    find_identifier
+    @identifier[:html_preview] = @identifier.preview
+  end
+
+  def destroy
+    find_identifier 
+    name = @identifier.title
+    pub = @identifier.publication
+    @identifier.destroy
+    
+    flash[:notice] = name + ' was successfully removed from your publication.'
+    redirect_to pub
+    return
+  end
+
+  protected
+    def find_identifier
+      @identifier = OajCiteIdentifier.find(params[:id].to_s)
+    end
+  
+    def find_publication_and_identifier
+      @publication = Publication.find(params[:publication_id].to_s)
+      find_identifier
+    end
+    
+     def find_publication
+      @publication = Publication.find(params[:publication_id].to_s)
+    end
+  
+end

--- a/app/helpers/agent_helper.rb
+++ b/app/helpers/agent_helper.rb
@@ -35,6 +35,13 @@ module AgentHelper
     return agent
   end
 
+  def self.get_target_collection(a_agent,a_type)
+    if (a_agent.nil? || a_agent[:collections].nil?)
+       return nil
+    end
+    a_agent[:collections][a_type]
+  end
+
   def self.get_client(a_agent)
     if (a_agent.nil?)
        return nil
@@ -114,8 +121,8 @@ module AgentHelper
       @client = HypothesisClient::Client.new(mapper_class.new)
     end
 
-    def get_content(a_uri)
-      @client.get(a_uri)
+    def get_content(a_uri,a_id,a_user)
+      @client.get(a_uri,a_id,a_user)
     end
 
 

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -450,7 +450,12 @@ class Identifier < ActiveRecord::Base
     change_desc_content = self.xml_content
     
     # assume context is from finalizing publication, so parent is board's copy
-    parent_classes = self.parent.owner.identifier_classes
+    if self.parent
+      parent_classes = self.parent.owner.identifier_classes
+    else
+      # if we created upon finalization we won't have a parent...
+      parent_classes = []
+    end  
     
     Comment.find_all_by_publication_id(self.publication.origin.id).each do |c|
       if((c.reason == "vote") && (parent_classes.include?(c.identifier.class.to_s)))
@@ -458,7 +463,6 @@ class Identifier < ActiveRecord::Base
         commit_message += " - Vote - #{c.comment} (#{c.user.human_name})\n"
       end
     end
-    
     change_desc_content = add_change_desc( "Finalized - " + comment_text, user, change_desc_content)
     commit_message += " - Finalized - #{comment_text} (#{user.human_name})"
     

--- a/app/models/oa_cite_identifier.rb
+++ b/app/models/oa_cite_identifier.rb
@@ -132,6 +132,7 @@ class OaCiteIdentifier < CiteIdentifier
   
   def preview parameters = {}, xsl = nil
     parameters[:e_convertResource] = AgentHelper::agents_can_convert
+    parameters[:e_createConverted] = self.publication.status == 'finalizing'
     JRubyXML.apply_xsl_transform(
       JRubyXML.stream_from_string(self.xml_content),
       JRubyXML.stream_from_file(File.join(Rails.root,

--- a/app/models/oaj_cite_identifier.rb
+++ b/app/models/oaj_cite_identifier.rb
@@ -1,0 +1,54 @@
+class OajCiteIdentifier < CiteIdentifier   
+  include OacHelper
+  require 'uuid'
+
+
+  FRIENDLY_NAME = "Annotation"
+  PATH_PREFIX="CITE_OA_JSON"
+  FILE_TYPE="oac.json"
+  ANNOTATION_TITLE = "Annotation"
+  
+  def titleize
+    title = self.name
+    return title
+  end
+
+  def self.new_from_supplied(a_publication,a_urn,a_init_content)
+    temp_id = self.new(:name => self.next_version_identifier(a_urn))
+    temp_id.publication = a_publication 
+    temp_id.save!
+    Rails.logger.info("initial content #{a_init_content}")
+    temp_id.set_xml_content(a_init_content, :comment => 'Created from Supplied content', :validate => true )
+    return temp_id
+  end
+
+  def is_valid_xml?(content)
+    true
+  end
+
+  def before_commit(content)
+    OajCiteIdentifier.preprocess(content)
+  end
+
+  def self.preprocess(content)
+    # make sure it parses - it should raise an error if not
+    JSON.parse(content)
+    content
+  end
+  
+  ## method which checks the cite object for an initialization  value
+  def is_match?(a_value) 
+    # for general OA Annotations we allow multiple on the same target 
+    return false
+  end
+  
+  def preview parameters = {}, xsl = nil
+    JSON.pretty_generate(JSON.parse(self.content))
+  end
+  
+  # need to update the uris to reflect the new name
+  def after_rename(options = {})
+     raise "Rename not supported yet!"
+  end
+
+end

--- a/app/models/oaj_cite_identifier.rb
+++ b/app/models/oaj_cite_identifier.rb
@@ -3,7 +3,7 @@ class OajCiteIdentifier < CiteIdentifier
   require 'uuid'
 
 
-  FRIENDLY_NAME = "Annotation"
+  FRIENDLY_NAME = "Annotation (JSON-LD)"
   PATH_PREFIX="CITE_OA_JSON"
   FILE_TYPE="oac.json"
   ANNOTATION_TITLE = "Annotation"
@@ -17,7 +17,6 @@ class OajCiteIdentifier < CiteIdentifier
     temp_id = self.new(:name => self.next_version_identifier(a_urn))
     temp_id.publication = a_publication 
     temp_id.save!
-    Rails.logger.info("initial content #{a_init_content}")
     temp_id.set_xml_content(a_init_content, :comment => 'Created from Supplied content', :validate => true )
     return temp_id
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -493,11 +493,13 @@ class Publication < ActiveRecord::Base
   #- +status_in+ the status to be set
   def set_origin_identifier_status(status_in)
       #finalizer is a user so they dont have a board, must go up until we find a board
+      #if we created an identifier on the publication during finalization it 
+      # won't have an origin and should be skipped
       board = self.find_first_board
       if board
               
         self.identifiers.each do |i|
-          if board.identifier_classes && board.identifier_classes.include?(i.class.to_s)
+          if board.identifier_classes && board.identifier_classes.include?(i.class.to_s) && i.origin
             i.origin.status = status_in
             i.origin.save
           end

--- a/app/views/oaj_cite_identifiers/_oaj_cite_identifier.haml
+++ b/app/views/oaj_cite_identifiers/_oaj_cite_identifier.haml
@@ -1,3 +1,4 @@
+= link_to 'Edit', edit_publication_oaj_cite_identifier_path( oaj_cite_identifier.publication, oaj_cite_identifier)
 = link_to 'Preview', preview_publication_oaj_cite_identifier_path( oaj_cite_identifier.publication, oaj_cite_identifier)
 - if @identifier.mutable? 
   = link_to 'Delete', polymorphic_path([oaj_cite_identifier.publication, oaj_cite_identifier]), :confirm => 'Are you sure?', :method => :delete

--- a/app/views/oaj_cite_identifiers/_oaj_cite_identifier.haml
+++ b/app/views/oaj_cite_identifiers/_oaj_cite_identifier.haml
@@ -1,0 +1,4 @@
+= link_to 'Preview', preview_publication_oaj_cite_identifier_path( oaj_cite_identifier.publication, oaj_cite_identifier)
+- if @identifier.mutable? 
+  = link_to 'Delete', polymorphic_path([oaj_cite_identifier.publication, oaj_cite_identifier]), :confirm => 'Are you sure?', :method => :delete
+%br

--- a/app/views/oaj_cite_identifiers/edit.haml
+++ b/app/views/oaj_cite_identifiers/edit.haml
@@ -1,0 +1,12 @@
+.main.edittext
+  = render :partial => 'identifiers/edit_bar'
+  .site
+    = render :partial => 'identifiers/header'
+    #edit
+      - form_for @identifier, :url => { :action => :update } do |f|
+        = f.error_messages
+        %label JSON-LD Object
+        %br
+        = f.text_area :xml_content, :disabled => !@identifier.mutable?, :rows => 20, :wrap => 'off', :class => 'observechange'
+        %br
+        = render :partial => 'identifiers/edit_commit', :locals => { :f => f, :identifier => @identifier, :where_at => :bottom }

--- a/app/views/oaj_cite_identifiers/preview.haml
+++ b/app/views/oaj_cite_identifiers/preview.haml
@@ -1,0 +1,8 @@
+#main
+  = render :partial => 'identifiers/edit_bar'
+  .site
+    = render :partial => 'identifiers/header'
+    .oaj_cite_preview
+      %label Preview
+      %pre
+        = @identifier[:html_preview]

--- a/config/agents.yml
+++ b/config/agents.yml
@@ -30,3 +30,5 @@
     :uri_match: "https://hypothes.is"
     :type: "hypothesis"
     :data_mapper: 'HypothesisClient::MapperPrototype::JOTH'
+    :collections:
+      :OajCiteIdentifier: "urn:cite:perseus:pdljann"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,5 +33,5 @@ REPOSITORY_ROOT = File.join(RAILS_ROOT, 'db', 'test', 'git')
 CANONICAL_CANONICAL_REPOSITORY = CANONICAL_REPOSITORY
 CANONICAL_REPOSITORY = File.join(REPOSITORY_ROOT, 'canonical.git')
 EXIST_STANDALONE_URL="http://localhost:8080"
-SITE_IDENTIFIERS = 'TeiCTSIdentifier,TeiTransCTSIdentifier,CitationCTSIdentifier,EpiCTSIdentifier,EpiTransCTSIdentifier,OACIdentifier,CTSInventoryIdentifier,CommentaryCiteIdentifier,TreebankCiteIdentifier,AlignmentCiteIdentifier'
+SITE_IDENTIFIERS = 'TeiCTSIdentifier,TeiTransCTSIdentifier,CitationCTSIdentifier,EpiCTSIdentifier,EpiTransCTSIdentifier,OACIdentifier,CTSInventoryIdentifier,CommentaryCiteIdentifier,TreebankCiteIdentifier,AlignmentCiteIdentifier,OajCiteIdentifier'
 SITE_CTS_INVENTORIES = 'testepi|Epi'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ ActionController::Routing::Routes.draw do |map|
     publication.resources :treebank_cite_identifiers, :member => { :create => :post, :history => :get, :preview => :get, :editxml => :get, :updatexml => :put, :exportxml => :get, :edit => :post, :rename_review => :get, :rename => :put, :api_get => :get, :api_update => :post, :edit_title => :get, :update_title => :put}
     publication.resources :alignment_cite_identifiers, :member => { :create => :post, :create_from_annotation => :get, :history => :get, :preview => :get, :editxml => :get, :updatexml => :put, :exportxml => :get, :edit => :post, :rename_review => :get, :rename => :put, :api_get => :get, :api_update => :post, :edit_title => :get, :update_title => :put}
     publication.resources :oa_cite_identifiers, :member => { :create => :post, :history => :get, :preview => :get, :annotate_xslt => :get, :editxml => :get, :import_update => :get, :updatexml => :put, :exportxml => :get, :edit_or_create => :post, :append => :post, :delete_annotation => :post, :update_from_agent => :post, :convert => :get }
+    publication.resources :oaj_cite_identifiers, :member => { :create => :post, :history => :get, :preview => :get }
 
     # publication.resources :identifiers
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,8 +80,8 @@ ActionController::Routing::Routes.draw do |map|
     publication.resources :commentary_cite_identifiers, :member => { :create => :post, :create_from_annotation => :get, :history => :get, :preview => :get, :editxml => :get, :update => :put, :exportxml => :get, :edit => :post, :rename_review => :get, :rename => :put}
     publication.resources :treebank_cite_identifiers, :member => { :create => :post, :history => :get, :preview => :get, :editxml => :get, :updatexml => :put, :exportxml => :get, :edit => :post, :rename_review => :get, :rename => :put, :api_get => :get, :api_update => :post, :edit_title => :get, :update_title => :put}
     publication.resources :alignment_cite_identifiers, :member => { :create => :post, :create_from_annotation => :get, :history => :get, :preview => :get, :editxml => :get, :updatexml => :put, :exportxml => :get, :edit => :post, :rename_review => :get, :rename => :put, :api_get => :get, :api_update => :post, :edit_title => :get, :update_title => :put}
-    publication.resources :oa_cite_identifiers, :member => { :create => :post, :history => :get, :preview => :get, :annotate_xslt => :get, :editxml => :get, :import_update => :get, :updatexml => :put, :exportxml => :get, :edit_or_create => :post, :append => :post, :delete_annotation => :post, :update_from_agent => :post, :convert => :get }
-    publication.resources :oaj_cite_identifiers, :member => { :create => :post, :history => :get, :preview => :get }
+    publication.resources :oa_cite_identifiers, :member => { :create => :post, :history => :get, :preview => :get, :annotate_xslt => :get, :editxml => :get, :import_update => :get, :updatexml => :put, :exportxml => :get, :edit_or_create => :post, :append => :post, :delete_annotation => :post, :update_from_agent => :post, :convert => :get, :rename_review => :get }
+    publication.resources :oaj_cite_identifiers, :member => { :create => :post, :history => :get, :preview => :get, :edit => :post, :update => :put, :rename_review => :get }
 
     # publication.resources :identifiers
   end

--- a/data/xslt/cite/oa_cite_preview.xsl
+++ b/data/xslt/cite/oa_cite_preview.xsl
@@ -12,6 +12,7 @@
     
     <xsl:output method="xhtml"/>
     <xsl:param name="e_convertResource" select="()"/>
+    <xsl:param name="e_createConverted" select="false()"/>
      
     <xsl:template match="/rdf:RDF">
     	<xsl:apply-templates select="oac:Annotation"/>
@@ -38,9 +39,19 @@
                 <xsl:variable name="resource" select="string(@rdf:resource)"/>
                 <xsl:for-each select="$e_convertResource">
                     <xsl:if test="matches($resource,.)">
+                        <xsl:variable name="convertLink">
+                          <xsl:choose>
+                            <xsl:when test="$e_createConverted = true()">
+                              <a class="oa_agent_convert" target="_new" href="convert?resource={encode-for-uri($resource)}&amp;format=json&amp;create=1">Create Conversion</a>
+                            </xsl:when>
+                            <xsl:otherwise>
+                              <a class="oa_agent_convert" target="_new" href="convert?resource={encode-for-uri($resource)}&amp;format=json">Export Conversion</a>
+                            </xsl:otherwise>
+                          </xsl:choose>
+                        </xsl:variable>
                         <div class="oac_convert">
                             <div class="oac_convert_preview"></div>
-                            <div class="oac_convert_link"><a class="oa_agent_convert" target="_new" href="convert?resource={encode-for-uri($resource)}&amp;format=json">Export Conversion</a></div>
+                            <div class="oac_convert_link"><xsl:copy-of select="$convertLink"/></div>
                         </div>         
                     </xsl:if>      
                 </xsl:for-each>          

--- a/data/xslt/cite/oa_cite_preview.xsl
+++ b/data/xslt/cite/oa_cite_preview.xsl
@@ -39,19 +39,15 @@
                 <xsl:variable name="resource" select="string(@rdf:resource)"/>
                 <xsl:for-each select="$e_convertResource">
                     <xsl:if test="matches($resource,.)">
-                        <xsl:variable name="convertLink">
-                          <xsl:choose>
-                            <xsl:when test="$e_createConverted = true()">
-                              <a class="oa_agent_convert" target="_new" href="convert?resource={encode-for-uri($resource)}&amp;format=json&amp;create=1">Create Conversion</a>
-                            </xsl:when>
-                            <xsl:otherwise>
-                              <a class="oa_agent_convert" target="_new" href="convert?resource={encode-for-uri($resource)}&amp;format=json">Export Conversion</a>
-                            </xsl:otherwise>
-                          </xsl:choose>
+                        <xsl:variable name="createLink">
+                            <xsl:if test="$e_createConverted = true()">
+                                <div class="oac_create_link"><a class="oa_agent_convert_create" href="convert?resource={encode-for-uri($resource)}&amp;format=json&amp;create=1">Create as Annotation</a></div>
+                            </xsl:if>
                         </xsl:variable>
                         <div class="oac_convert">
                             <div class="oac_convert_preview"></div>
-                            <div class="oac_convert_link"><xsl:copy-of select="$convertLink"/></div>
+                            <div class="oac_convert_link"><a class="oa_agent_convert" target="_new" href="convert?resource={encode-for-uri($resource)}&amp;format=json">Export Conversion</a></div>
+                            <xsl:copy-of select="$createLink"/>
                         </div>         
                     </xsl:if>      
                 </xsl:for-each>          

--- a/lib/cite.rb
+++ b/lib/cite.rb
@@ -1,5 +1,6 @@
 module Cite
   require 'jruby_xml'
+  require 'uuid'
   
   class CiteError < ::StandardError
   end
@@ -140,6 +141,15 @@ module Cite
       # @param {String} a_urn
       def get_creatable_identifiers(a_urn)
         
+      end
+
+      # return an object urn that assignes a uuid as the object id
+      def object_uuid_urn(a_collection_urn)
+        if (is_collection_urn?(a_collection_urn))
+          return "#{a_collection_urn}.#{UUID.new.generate(:compact)}"
+        else 
+          raise "Invalid collection urn"
+        end
       end
     end # end class
   end # end module CiteLib

--- a/public/stylesheets/perseus.css
+++ b/public/stylesheets/perseus.css
@@ -526,7 +526,7 @@ li.editor_menu {
     background-color: #EAEAEA;
 }
 
-.oa_cite_annotation .oac_convert_preview pre {
+.oa_cite_annotation .oac_convert_preview pre, .oaj_cite_preview pre {
     height: 400px;
     overflow: scroll;
     color: white;

--- a/test/unit/data/valid.json
+++ b/test/unit/data/valid.json
@@ -1,0 +1,53 @@
+{
+  "@context": "http://www.w3.org/ns/oa-context-20130208.json",
+  "@id": "https://hypothes.is/a/vkOKvSE-S2qlFCNrGbUaUA",
+  "annotatedBy": {
+    "@type": "foaf:Person",
+    "@id": "SCTM@hypothes.is"
+    },
+  "@type": "oa:Annotation",
+  "dcterms:source": "https://hypothes.is/a/vkOKvSE-S2qlFCNrGbUaUA",
+  "dcterms:title": "http://data.perseus.org/people/smith:eetion-1#this identifies Eetion as snap:FatherOf in urn:cts:pdlrefwk:viaf88890045.003.perseus-eng1:andromache_1",
+  "annotatedAt": "2015-02-04T21:50:09.561419+00:00",
+  "motivatedBy": "oa:identifying",
+  "serializedBy": {
+    "@id": "https://hypothes.is",
+    "@type": "prov:SoftwareAgent"
+    },
+  "hasTarget": {
+    "@id": "https://hypothes.is/a/vkOKvSE-S2qlFCNrGbUaUA#target-1",
+    "@type": "oa:SpecificResource",
+    "hasSource": {
+      "@id": "urn:cts:pdlrefwk:viaf88890045.003.perseus-eng1:andromache_1"
+            },
+    "hasSelector": {
+      "@id": "https://hypothes.is/a/vkOKvSE-S2qlFCNrGbUaUA#target-1-sel-1",
+      "@type": "oa:TextQuoteSelector",
+      "exact": "Eetion",
+      "prefix": "ache （Ἀνδρομάχη), a daughter of",
+      "suffix": ", king of the Cilician Thebae, a"
+            }
+    },
+  "hasBody": {
+    "@context": {
+      "snap": "http://onto.snapdrgn.net/snap#",
+      "lawd": "http://lawd.info/ontology/",
+      "perseusrdf": "http://data.perseus.org/rdfvocab/addons/"
+            },
+    "@graph": [
+      {
+        "@id": "http://data.perseus.org/people/smith:andromache-1#this",
+        "snap:has-bond": {
+          "@id": "https://hypothes.is/a/vkOKvSE-S2qlFCNrGbUaUA#bond-1"
+                                        }
+                        },
+      {
+        "@id": "https://hypothes.is/a/vkOKvSE-S2qlFCNrGbUaUA#bond-1",
+        "@type": "snap:FatherOf",
+        "snap:bond-with": {
+          "@id": "http://data.perseus.org/people/smith:eetion-1#this"
+                                        }
+                        }
+    ]
+    }
+}

--- a/test/unit/oaj_cite_identifier_test.rb
+++ b/test/unit/oaj_cite_identifier_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class OajCiteIdentifierTest < ActiveSupport::TestCase
+  
+  context "identifier test" do
+    setup do
+      @creator = Factory(:user, :name => "Creator")
+      @publication = Factory(:publication, :owner => @creator, :creator => @creator, :status => "new")
+
+      # branch from master so we aren't just creating an empty branch
+      @publication.branch_from_master
+    
+    end
+    
+    teardown do
+      unless @publication.nil?
+        @publication.destroy
+      end
+      unless @creator.nil?
+        #@creator.destroy
+      end
+    end
+
+    should "work with valid" do
+      init_value = File.read(File.join(File.dirname(__FILE__), 'data', 'valid.json'))
+      urn = "urn:cite:perseus:pdljann.123456"
+      test = OajCiteIdentifier.new_from_supplied(@publication,urn,init_value)
+      assert_not_nil test
+      assert_equal "urn:cite:perseus:pdljann.123456.1", test.urn_attribute
+    end
+
+    should "raise error" do
+      urn = "urn:cite:perseus:pdljann.123456"
+      init_value = "<xml>junk</xml>"
+      exception = assert_raises(JSON::ParserError) {
+        test = OajCiteIdentifier.new_from_supplied(@publication,urn,init_value)
+       }
+    end
+
+  end
+   
+end

--- a/vendor/gems/hypothesis-client-0.0.1/lib/hypothesis-client/client.rb
+++ b/vendor/gems/hypothesis-client-0.0.1/lib/hypothesis-client/client.rb
@@ -13,7 +13,7 @@ module HypothesisClient
       @mapper = mapper
     end
 
-    def get(a_uri)
+    def get(a_uri,a_id=nil,a_owner=nil)
       respobj = {}
       begin
         uri = URI.parse(a_uri)
@@ -26,7 +26,8 @@ module HypothesisClient
         if (response.code == '200') 
           respobj = { }
           orig_annot = JSON.parse(response.body)
-          mapped = map(a_uri,orig_annot)
+          new_id = a_id.nil? ? a_uri : a_id
+          mapped = map(new_id,orig_annot,a_owner)
           if (mapped[:errors].length > 0) 
             respobj[:is_error] = true
             respobj[:error] = mapped[:errors].join("\n")
@@ -47,8 +48,8 @@ module HypothesisClient
       
     end
 
-    def map(source,data)
-      @mapper.map(AGENT_URI,source,data,FORMAT_OALD)
+    def map(source,data,owner=nil)
+      @mapper.map(AGENT_URI,source,data,FORMAT_OALD,owner)
     end
 
   end

--- a/vendor/gems/hypothesis-client-0.0.1/lib/hypothesis-client/client.rb
+++ b/vendor/gems/hypothesis-client-0.0.1/lib/hypothesis-client/client.rb
@@ -26,6 +26,7 @@ module HypothesisClient
         if (response.code == '200') 
           respobj = { }
           orig_annot = JSON.parse(response.body)
+          orig_annot[:sourceUri] = uri.to_s
           new_id = a_id.nil? ? a_uri : a_id
           mapped = map(new_id,orig_annot,a_owner)
           if (mapped[:errors].length > 0) 
@@ -48,8 +49,8 @@ module HypothesisClient
       
     end
 
-    def map(source,data,owner=nil)
-      @mapper.map(AGENT_URI,source,data,FORMAT_OALD,owner)
+    def map(id,data,owner=nil)
+      @mapper.map(AGENT_URI,id,data,FORMAT_OALD,owner)
     end
 
   end

--- a/vendor/gems/hypothesis-client-0.0.1/lib/hypothesis-client/mapper_prototype.rb
+++ b/vendor/gems/hypothesis-client-0.0.1/lib/hypothesis-client/mapper_prototype.rb
@@ -82,7 +82,8 @@ module HypothesisClient::MapperPrototype
     # @param source the URI of the original hypothes.is annotation
     # @param data the Hypothes.is data
     # @param format expected output format -- only HypothesisClient::Client::FORMAT_OALD supported
-    def map(agent,source,data,format)
+    # @param owner uri for the annotation
+    def map(agent,source,data,format,owner=nil)
       response = {} 
       response[:errors] = []
       model = {}
@@ -91,7 +92,7 @@ module HypothesisClient::MapperPrototype
       begin
         model[:agentUri] = agent
         model[:sourceUri] = source
-        model[:userid] = data["user"].sub!(/^acct:/,'')
+        model[:userid] = owner.nil? ? data["user"].sub!(/^acct:/,'') : owner
         # if we have updated at, use that as annotated at, otherwise use created 
         model[:date] = data["updated"] ? data["updated"]: data["created"]
         body_tags = {}

--- a/vendor/gems/hypothesis-client-0.0.1/spec/mapper_spec.rb
+++ b/vendor/gems/hypothesis-client-0.0.1/spec/mapper_spec.rb
@@ -149,4 +149,12 @@ describe HypothesisClient::MapperPrototype do
        expect { parsed = $mapper.parse_urn("urn:cts:greekLit:tlg0012")}.to raise_error
     end
   end
+  context "owner test" do 
+    input = File.read(File.join(File.dirname(__FILE__), 'support', 'test1.json')) 
+    let(:mapped) { client.map("test",JSON.parse(input),'http://example.org/user/abc')}
+
+    it 'mapped the source uri' do
+      expect(mapped[:data]["annotatedBy"]['@id']).to eq('http://example.org/user/abc')
+    end
+  end
 end

--- a/vendor/gems/hypothesis-client-0.0.1/spec/mapper_spec.rb
+++ b/vendor/gems/hypothesis-client-0.0.1/spec/mapper_spec.rb
@@ -15,7 +15,7 @@ describe HypothesisClient::MapperPrototype do
     end
 
     it 'mapped the source uri' do
-      expect(mapped[:data]["dcterms:source"]).to eq('test')
+      expect(mapped[:data]["dcterms:source"]).to eq(nil)
     end
 
     it 'mapped the body text' do

--- a/vendor/gems/hypothesis-client-0.0.1/spec/support/attest1.json
+++ b/vendor/gems/hypothesis-client-0.0.1/spec/support/attest1.json
@@ -1,0 +1,73 @@
+{
+    "permissions": {
+        "delete": [
+            "acct:balmas@hypothes.is"
+        ], 
+        "admin": [
+            "acct:balmas@hypothes.is"
+        ], 
+        "update": [
+            "acct:balmas@hypothes.is"
+        ], 
+        "read": [
+            "group:__world__"
+        ]
+    }, 
+    "consumer": "00000000-0000-0000-0000-000000000000", 
+    "tags": [
+        "attestation"
+    ], 
+    "created": "2015-02-25T20:12:37.523941+00:00", 
+    "text": "http://data.perseus.org/citations/urn:cts:greekLit:tlg0525.tlg001.perseus-eng1:10.35.1\nAbas", 
+    "target": [
+        {
+            "pos": {
+                "height": 18, 
+                "top": 308.95001220703125
+            }, 
+            "selector": [
+                {
+                    "startContainer": "/div[3]/div[2]/div[3]/div[2]/div[1]/div[1]/span[1]", 
+                    "type": "RangeSelector", 
+                    "startOffset": 0, 
+                    "endOffset": 19, 
+                    "endContainer": "/div[3]/div[2]/div[3]/div[2]/div[1]/div[1]"
+                }, 
+                {
+                    "start": 2500, 
+                    "type": "TextPositionSelector", 
+                    "end": 2510
+                }, 
+                {
+                    "exact": "*)Abai=os)", 
+                    "suffix": ", a surname of Apollo derived fr", 
+                    "type": "TextQuoteSelector", 
+                    "prefix": "M N O P Q R S T U/V X Z Abaeus \uff08"
+                }, 
+                {
+                    "type": "FragmentSelector", 
+                    "value": ""
+                }
+            ], 
+            "source": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus:text:1999.04.0104"
+        }
+    ], 
+    "document": {
+        "twitter": {}, 
+        "link": [
+            {
+                "href": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.04.0104"
+            }
+        ], 
+        "prism": {}, 
+        "eprints": {}, 
+        "title": "\n\nA Dictionary of Greek and Roman biography and mythology,\nAbaeus  \n", 
+        "highwire": {}, 
+        "facebook": {}, 
+        "dc": {}
+    }, 
+    "updated": "2015-02-25T20:12:37.523970+00:00", 
+    "uri": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus:text:1999.04.0104:alphabetic+letter=C:entry+group=29:entry=clytaemnestra-bio-1",
+    "user": "acct:balmas@hypothes.is", 
+    "id": "CZZbvlxmRjmV_LzfCxqPyA"
+}


### PR DESCRIPTION
For PerseusDL/perseids_docs#212

This pull request adds support for a new type of Cite Identifer -- the oaj_cite_identifier, for json-ld representations using the OA data model.

Right now this identifier type is only created from oa_cite_identifiers, to represent the conversion of an imported hypothes.is annotation converted via the hypothesis-client mapper prototype for the Journey of the Hero Workflow.

In our current implementation, these identifiers are only created at finalization time of an oa_cite_identifier.  This is to allow greater reviewer controller over the process for now, as the conversion is very experimental and relies on strict adherence to our guidelines for annotating in Hypothes.is (https://github.com/PerseusDL/perseids_docs/wiki/hypothes.is-annotations).  Ideally these should actually be created on ingest of the annotations from hypothes.is but this could be problematic for large imports as each conversion requires a call to the hypothes.is API. We really need support for asynchronous jobs in SoSOL for this to work smoothly. So for now it's a manual workflow which allows the finalizer to explicitly create each new annotation. Not perfect but moves us forward a little bit.